### PR TITLE
#10 Return `text/javascript` content type header for JavaScript files

### DIFF
--- a/src/http_parser/http_fieldname.rs
+++ b/src/http_parser/http_fieldname.rs
@@ -3,15 +3,17 @@ use core::fmt;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum HttpFieldName {
     ContentLength,
-    Host
+    ContentType,
+    Host,
 }
 
 impl HttpFieldName {
     pub fn from_str(field_name: &str) -> Option<Self> {
         // As field names are case-insensitive, `field_name` and the cases below must be the same case
         match field_name.trim().to_ascii_lowercase().as_str() {
-            "host" => Some(Self::Host),
             "content-length" => Some(Self::ContentLength),
+            "content-type" => Some(Self::ContentType),
+            "host" => Some(Self::Host),
             _ => None
         }
     }
@@ -20,8 +22,9 @@ impl HttpFieldName {
 impl fmt::Display for HttpFieldName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let field_name = match self {
+            Self::ContentLength => "Content-Length",
+            Self::ContentType => "Content-Type",
             Self::Host => "Host",
-            Self::ContentLength => "Content-Length"
         };
         write!(f, "{field_name}")
     }

--- a/src/http_parser/http_header.rs
+++ b/src/http_parser/http_header.rs
@@ -75,8 +75,9 @@ impl fmt::Display for HttpHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut output = String::new();
         for (key, value) in &self.0 {
-            output.push_str(&format!("{key}: {value}"));
+            output.push_str(&format!("{key}: {value}\n"));
         }
+        let _ = output.split_off(output.len() - 1);
         write!(f, "{output}")
     }
 }

--- a/src/http_parser/http_request.rs
+++ b/src/http_parser/http_request.rs
@@ -33,7 +33,8 @@ impl HttpRequest<'_> {
     /// # Bad Data
     /// If the request doesn't contain a full, understood request header (method, target
     /// and HTTP version), this function will return a [`Processing<Finished<Result<(Error, HttpStatusCode)>>>`]
-    /// with a recommended [`HttpStatusCode`]. If field names are unknown, the field will be ignored.
+    /// with a recommended [`HttpStatusCode`].
+    /// If field names are unknown, the field will be ignored.
     /// If field names or field values contain non-UTF8 characters, the entire field line will be ignored.
     /// No parsing will be done on the body.
     pub fn try_parse<'a>(partial_request: &PartialHttpRequest<'a>, request_bytes: &'a [u8]) -> Processing<PartialHttpRequest<'a>, Result<HttpRequest<'a>, (io::Error, HttpStatusCode)>> {
@@ -65,8 +66,8 @@ impl HttpRequest<'_> {
                 Some(before_delimiter) => match std::str::from_utf8(before_delimiter) {
                     Err(_) => return not_implemented,
                     Ok(slice) => match HttpTarget::from_str(slice) {
-                        Err(_) => return not_implemented,
-                        Ok(target) => Some(target),
+                        None => return bad_request,
+                        Some(target) => Some(target),
                     },
                 },
             }

--- a/src/http_parser/http_target.rs
+++ b/src/http_parser/http_target.rs
@@ -15,28 +15,26 @@ impl HttpTarget {
         }
     }
 
-    pub fn from_str(target: &str) -> Result<Self, ()> {
+    pub fn from_str(target: &str) -> Option<Self> {
+        if target.is_empty() {
+            return None
+        }
+        
         let parameter_delimiter = '?';
         // let filepath = match Filepath::from_str(target) {
         //     Err(_) => None,
         //     Ok(path) => Some(path),
         // };
         let path = match target.split_once(parameter_delimiter) {
-            None => Some(target.to_owned()),
-            Some((path, _)) => Some(path.to_owned()),
+            None => target.to_owned(),
+            Some((path, _)) => path.to_owned(),
         };
-        let parameters = match HttpTargetParameters::from_str(target) {
-            Err(_) => None,
-            Ok(parameters) => Some(parameters),
-        };
-        if !path.is_none() || !parameters.is_none() {
-            Ok(HttpTarget {
-                path,
-                parameters,
-            })
-        } else {
-            Err(())
-        }
+        let parameters = HttpTargetParameters::from_str(target);
+
+        Some(HttpTarget {
+            path: Some(path),
+            parameters,
+        })
     }
 
     pub fn directory(&self) -> Option<&str> {

--- a/src/http_parser/http_target_parameters.rs
+++ b/src/http_parser/http_target_parameters.rs
@@ -4,7 +4,7 @@ use std::collections::{hash_map, HashMap};
 pub struct HttpTargetParameters(HashMap<String, Vec<String>>);
 
 impl HttpTargetParameters {
-    pub fn from_str(target: &str) -> Result<Self, ()> {
+    pub fn from_str(target: &str) -> Option<Self> {
         let mut parameters = HashMap::new();
         let query_delimiter = '?';
         let target = match target.find(query_delimiter) {
@@ -44,8 +44,8 @@ impl HttpTargetParameters {
             }
         }
         match parameters.len() {
-            0 => Err(()),
-            _ => Ok(Self(parameters)),
+            0 => None,
+            _ =>Some(Self(parameters)),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,6 +116,9 @@ fn http_head(config: &Config, http_request: &mut HttpRequest) -> Result<HttpResp
 
     let mut http_header = HttpHeader::new();
     http_header.insert(HttpFieldName::ContentLength.to_string().as_str(), metadata.len().to_string().as_str());
+    if path.ends_with(".js") || path.ends_with(".mjs") {
+        http_header.insert(HttpFieldName::ContentType.to_string().as_str(), "text/javascript");
+    }
 
     Ok(HttpResponse {
         version: http_version.clone(),
@@ -231,7 +234,6 @@ fn get_target_prefix(config: &Config, http_request: &HttpRequest) -> String {
 /// let path = subdomain_as_path(subdomain);
 /// assert_eq!("shop/uk", path);
 /// ```
-/// 
 fn subdomain_as_path(subdomain: &str) -> String {
     let subdomain_delimiter = '.';
     let path_separator = '/';


### PR DESCRIPTION
Closes #10.